### PR TITLE
Rare assert/crash when allocation counter underflows

### DIFF
--- a/LiquidFun-1.1.0/src/liquidfun/Box2D/Box2D/Common/b2Settings.cpp
+++ b/LiquidFun-1.1.0/src/liquidfun/Box2D/Box2D/Common/b2Settings.cpp
@@ -98,8 +98,11 @@ void* b2Alloc(int32 size)
 
 void b2Free(void* mem)
 {
-	b2_numAllocs--;
-	b2_freeCallback(mem, b2_callbackData);
+	if (mem != NULL)
+	{
+		b2_numAllocs--;
+		b2_freeCallback(mem, b2_callbackData);
+	}
 }
 
 void b2SetNumAllocs(const int32 numAllocs)


### PR DESCRIPTION
Fixed an issue where `b2_numAllocs` could get a negative value, causing an assert/crash under certain conditions.