### PR TITLE
Updated premake with better CodeLite and Visual Studio support for language standard flags

### DIFF
--- a/premake/src/actions/codelite/codelite_project.lua
+++ b/premake/src/actions/codelite/codelite_project.lua
@@ -78,7 +78,7 @@
 				_p('      <General OutputFile="%s" IntermediateDirectory="$(ConfigurationName)" Command="./%s" CommandArguments="%s" WorkingDirectory="%s" PauseExecWhenProcTerminates="%s"/>', fname, runcmd, runargs, rundir, pause)
 
 				-- begin compiler block --
-				local cflags = premake.esc(table.join(premake.gcc.getcflags(cfg), cfg.buildoptions))
+				local cflags = premake.esc(table.join(premake.gcc.getcflags(cfg), premake.gcc.getcstdflags(cfg), cfg.buildoptions))
 				local cppflags = premake.esc(table.join(premake.gcc.getcflags(cfg), premake.gcc.getcxxflags(cfg), cfg.buildoptions))
 				_p('      <Compiler Required="yes" Options="%s" C_Options="%s">', table.concat(cppflags, ";"), table.concat(cflags, ";"))
 				for _,v in ipairs(cfg.includedirs) do

--- a/premake/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/premake/src/actions/vstudio/vs2010_vcxproj.lua
@@ -282,7 +282,7 @@
 		end
 
 		if cfg.flags.CXX11 then
-			_p(3,'<LanguageStandard>stdcpp11</LanguageStandard>')
+			_p(3,'<LanguageStandard>stdcpp14</LanguageStandard>')
 		elseif cfg.flags.CXX14 then
 			_p(3,'<LanguageStandard>stdcpp14</LanguageStandard>')
 		elseif cfg.flags.CXX17 then


### PR DESCRIPTION
- Add C version standard flags to CodeLite config
- Visual Studio doesn't support C++11, so push to C++14 when it's specified